### PR TITLE
Remove redundant component (already defined via parent class CamBase).

### DIFF
--- a/profile_bluesky/startup/10-devices.py
+++ b/profile_bluesky/startup/10-devices.py
@@ -116,7 +116,6 @@ class PSO_Device(Device):
 
 class MyPcoCam(PcoDetectorCam):
     """PCO Dimax detector"""
-    array_callbacks = Component(EpicsSignal, "ArrayCallbacks")
     pco_cancel_dump = Component(EpicsSignal, "pco_cancel_dump")
     pco_live_view = Component(EpicsSignal, "pco_live_view")
     pco_trigger_mode = Component(EpicsSignal, "pco_trigger_mode")


### PR DESCRIPTION
Very minor cleanup. See here that ``PcoDetectorCam`` already has
the ``array_callbacks`` component via its parent class.

```py
In [1]: from ophyd import PcoDetectorCam

In [2]: PcoDetectorCam.__mro__
Out[2]:
(ophyd.areadetector.cam.PcoDetectorCam,
 ophyd.areadetector.cam.CamBase,
 ophyd.areadetector.base.ADBase,
 ophyd.device.Device,
 ophyd.device.BlueskyInterface,
 ophyd.ophydobj.OphydObject,
 object)

In [3]: from ophyd import CamBase

In [4]: CamBase.array_callbacks
Out[4]: ADComponent(EpicsSignalWithRBV, 'ArrayCallbacks')
```